### PR TITLE
basicZ80: fix PEEK(x), returned values were 256 below the real value

### DIFF
--- a/basicZ80.asm
+++ b/basicZ80.asm
@@ -872,11 +872,11 @@ UsrSub:
 	EX DE,HL
 	JP (HL)
 	
-PeekSub:
-	EX DE,HL
-	LD E,(HL)
-	DEC D
-	RET
+PeekSub:		;return byte from address in DE
+	EX DE,HL	;now: HL = address, DE = 00A8
+	LD E,(HL)	;get byte from address
+	NOP 		;D is already 00
+	RET		;return result in DE
 
 RndSub:
 ; LCG 


### PR DESCRIPTION
DEC D is not necessary b/c D is already 0 (HL is 0xA8 at function entry)